### PR TITLE
Allow absolute paths to be passed to the parser

### DIFF
--- a/bin/blessc
+++ b/bin/blessc
@@ -65,10 +65,12 @@ args = args.filter(function (arg) {
 
 var input = args[1];
 if (input && input[0] != '/' && input != '-') {
+	if(/^\w:[\\/]/.test(input)) input = path.relative(process.cwd(), input);
     input = path.join(process.cwd(), input);
 }
 var output = args[2];
 if (output && output[0] != '/') {
+	if(/^\w:[\\/]/.test(output)) output = path.relative(process.cwd(), output);
     output = path.join(process.cwd(), output);
 }
 


### PR DESCRIPTION
There are use cases where it is very convenient to pass an absolute file path to the parser, though currently the code appends any input/output string to the end of the current working directory. This results in the generation of the incorrect file path that prevents absolute paths from being passed.

This will resolve #22.
