### PR TITLE
Add Contributing and Maintaining documentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.js]
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,48 @@
+# Contributing
+
+We welcome community support with both pull requests and reporting bugs. Please
+don't hesitate to jump in.
+
+## Review others work
+
+Check out the list of outstanding pull requests if there is something you might
+be interested in. Maybe somebody is trying to fix that stupid bug that bothers
+you. Review the PR. Do you have any better ideas how to fix this problem? Let us
+know...
+
+## Issues
+
+The issue tracker is the preferred channel for bug reports, features requests
+and submitting pull requests.
+
+Feel free to tackle any currently open [issue][issues]. The issues tagged with
+"help wanted" are fair game.
+
+## Tests
+
+All commits that fix bugs or add features need a test.
+
+## Code Style
+
+Please adhere to the current code styling. We have included an `.editorconfig`
+at the repo's root to facilitate uniformity regardless of your editor. See the
+[editor config site][editorconfig] for integration details.
+
+We use [ESLint][eslint] for all JavaScript Linting. There should be no linting
+errors and no new warnings for new work. You are welcome to configure your
+editor to use ESLint or the `npm test` command will run unit tests and the
+linter.
+
+## Docs
+
+Please update the docs with any API changes, the code and docs should always be
+in sync.
+
+## Collaborators
+
+Please see the [Maintaining](./MAINTAINING.md) documentation.
+
+[issues]: https://github.com/BlessCSS/bless/issues
+
+[editorconfig]: http://editorconfig.org
+[eslint]: http://eslint.org

--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -1,0 +1,59 @@
+# Maintaining Bless
+
+This document is primarily for members of the BlessCSS organization, though
+publicly available for your viewing pleasure. It describes how we work as a team
+to provide our downstream users with a great product. You will find descriptions
+for common tasks such as triaging, merging pull requests, and release
+procedures.
+
+If you are interested in contributing to Bless, you should check out the
+[Contributing Guide](./CONTRIBUTING.md).
+
+## Triaging Issues
+
+When new issues pop up we need to identify urgent issues (such as nobody can use
+the tool, or install Bless), close and link duplicate issues, answer questions,
+etc.  Please alert the [gitter/bless](https://gitter.im/BlessCSS/bless) chat
+room of the urgent issues.
+
+Some issues are opened that are just too vague to do anything about. If after
+attempting to get feedback from issue authors fails after 7 days, then close the
+issue. Please inform the issue author that they may re-open if they are able to
+present the requested information.
+
+## Merging a pull request
+
+Please, make sure:
+
+- Travis build is green
+- Review the code to ensure quality is sufficient. The code should be clean and
+  easy to read, tested and if public facing documented.
+- At least one collaborator (other than you) approves the PR
+  - Commenting "LGTM" (Looks good to me) or something of similar sorts is
+    sufficient.
+  - If it's a simple docs change or a typo fix, feel free to skip this step.
+
+## Becoming a maintainer
+
+If you are interested in becoming a Bless maintainer, start by reviewing issues
+and pull requests. Answer questions for those in need of troubleshooting. Join
+us in the [gitter/bless](https://gitter.im/BlessCSS/bless) chat room. Once we
+see you helping, either we will reach out and ask you if you want to join or you
+can ask one of the [organization
+owners](https://github.com/orgs/BlessCSS/teams/owners) to add you. We will try
+our best to be proactive in reaching out to those that are already helping out.
+
+GitHub by default does not publicly state that you are a member of the
+organization. Please feel free to change that setting for yourself so others
+will know who's helping out. That can be configured on the [organization
+list](https://github.com/orgs/BlessCSS/people) page.
+
+Being a maintainer is not an obligation. You can help when you have time and be
+less active when you don't. If you get a new job and get busy, that's alright.
+
+## Releases
+
+Releases should include documentation, git tag, and finally the actual npm
+module publish. New versions should follow [SemVer](http://semver.org/)
+versioning constraints. If it is determined that such has been violated that
+release should be deprecated and patched as soon as possible.


### PR DESCRIPTION
I'd like to add some documentation about what we expect from our contributors and from ourselves as a team. Part of my goal over the next few weeks is to see if we can get some of the downstream build plugin authors to join the organization and help us maintain it.

@paulyoung
@aabenoja 