### PR TITLE
Ignore charset AST

### DIFF
--- a/src/count.js
+++ b/src/count.js
@@ -20,6 +20,7 @@ function count(ast) {
     case 'keyframes':
     case 'import':
     case 'supports':
+    case 'charset':
       return 0;
     default:
       return countRules(ast.rules);


### PR DESCRIPTION
If CSS begins with charset, bless fails.
```css
@charset "UTF-8";
```