### PR TITLE
Revert "Add Bluebird Promise library to fix Node 0.10 bug"

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   },
   "dependencies": {
     "babel-runtime": "^5.1.11",
-    "bluebird": "^2.9.34",
     "colors": "^1.0.3",
     "columnify": "^1.4.1",
     "css": "^2.2.0",


### PR DESCRIPTION
Reverts BlessCSS/bless#74

This is the actual culprit, for some reason this was failing tests but the test exit code did not tell travis about the failure