### PR TITLE
Fixed missing repository in 3.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "url"             : "http://blesscss.com",
   "keywords"        : ["css", "parser", "bless", "less", "sass", "stylus"],
   "author"          : "Paul Young <paulyoungonline+bless@gmail.com>",
+  "repository"      : "BlessCSS/bless",
   "contributors"    : [],
   "version"         : "3.0.3",
   "bin"             : { "blessc": "./bin/blessc" },


### PR DESCRIPTION
During `npm install` a warning is thrown that the repository field is missing. I've used the repository field that was added in the master branch. Would it be possible to create a maintenance release for this?