### PR TITLE
Remove colors.js and replace it with chalk.

### DIFF
--- a/bin/blessc
+++ b/bin/blessc
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /* eslint no-var: 0, no-process-exit: 0 */
 
-require('colors');
+var chalk = require('chalk');
 var entry = require(require('path').join(__dirname, '..', 'lib', 'cli'));
 
 entry(process.argv)
@@ -9,6 +9,6 @@ entry(process.argv)
     process.exit(exitCode);
   })
   .catch(function(err) {
-    console.log(err.toString().red);
+    console.log(chalk.red(err.toString()));
     process.exit(1);
   });

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "babel-runtime": "^6.6.1",
-    "colors": "^1.0.3",
+    "chalk": "^1.1.3",
     "columnify": "^1.4.1",
     "css": "^2.2.0",
     "format-number": "^2.0.1",

--- a/run-tests
+++ b/run-tests
@@ -1,7 +1,7 @@
 #!/usr/bin/env babel-node
 /* eslint no-process-exit: 0 */
 
-import 'colors';
+import chalk from 'chalk';
 import { exec, spawn } from 'child-process-promise';
 
 const isCI = process.env.CONTINUOUS_INTEGRATION === 'true';
@@ -17,7 +17,7 @@ function myspawn(command) {
 myspawn('npm run lint')
   .then(() => myspawn('mocha --compilers js:babel-core/register'))
   .then(() => {
-    console.log('Gathering Code Coverage...\n'.cyan);
+    console.log(chalk.cyan('Gathering Code Coverage...\n'));
     return exec('rm -rf ./.coverage');
   })
   .then(() => myspawn('babel-node node_modules/babel-istanbul/lib/cli.js cover node_modules/mocha/bin/_mocha -- --reporter dot'))
@@ -27,6 +27,10 @@ myspawn('npm run lint')
     }
   })
   .catch(err => {
-    console.log(err);
+    if (err.stack) {
+        console.error(err.stack);
+    } else {
+        console.error(err);
+    }
     process.exit(1);
   });

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,5 +1,5 @@
 /* eslint no-process-exit: 0 */
-import 'colors';
+import chalk from 'chalk';
 import yargs from 'yargs';
 import parseCliArgs from './parse-cli-args';
 
@@ -9,9 +9,9 @@ export default function cliExeute(argv) {
   try {
     command = parseCliArgs(argv);
   } catch(err) {
-    console.log(`Failed: ${err.toString()}`.red);
+    console.log(chalk.red(`Failed: ${err.toString()}`));
     if (err.stack) {
-      console.log(err.stack.red);
+      console.log(chalk.red(err.stack));
     }
     console.log('');
     yargs.showHelp();

--- a/src/commands/chunk.js
+++ b/src/commands/chunk.js
@@ -1,4 +1,4 @@
-import 'colors';
+import chalk from 'chalk';
 import yargs from 'yargs';
 import common from './common-yargs';
 import { chunkFile } from '../index';
@@ -42,7 +42,7 @@ function execute(options) {
     .reduce((acc, x) => acc.concat([x]), [])
     .toPromise(Promise)
     .then(() => {
-      console.log('Complete'.green);
+      console.log(chalk.green('Complete'));
       return 0;
     });
 }

--- a/src/commands/common-yargs.js
+++ b/src/commands/common-yargs.js
@@ -1,8 +1,9 @@
+import chalk from 'chalk';
 import yargs from 'yargs';
 import { version } from '../../package.json';
 
 export default function appendCommon() {
-  yargs.usage(`BlessCSS v${version}`.magenta + ` - Tools to ensure CSS files meet IE 6-9 selector limit restrictions.`)
+  yargs.usage(chalk.magenta(`BlessCSS v${version}`) + ` - Tools to ensure CSS files meet IE 6-9 selector limit restrictions.`)
     .epilogue('For additional information see http://blesscss.com')
     .wrap(null);
 }

--- a/src/commands/count.js
+++ b/src/commands/count.js
@@ -3,7 +3,7 @@ import yargs from 'yargs';
 import common from './common-yargs';
 import path from 'path';
 import { countPath } from '../count';
-import colors from 'colors';
+import chalk from 'chalk';
 import numberFormatter from 'format-number';
 import columnify from 'columnify';
 import { SELECTOR_LIMIT } from '../constants';
@@ -13,7 +13,7 @@ const formatNumber = numberFormatter();
 function format(results, srcPath) {
   let formattedData = results
     .map(x => {
-      let color = x.exceedsLimit ? colors.red : colors.green;
+      let color = x.exceedsLimit ? chalk.red : chalk.green;
       let relativeFilepath = path.relative(srcPath, x.filepath);
       let formattedNumber = formatNumber(x.selectorCount);
 
@@ -27,10 +27,10 @@ function format(results, srcPath) {
     columnSplitter: '    ',
     config: {
       filepath: {
-        headingTransform() { return 'File Path'.bold.underline; }
+        headingTransform() { return chalk.bold.underline('File Path'); }
       },
       selectorCount: {
-        headingTransform() { return `Selector Count (Limit: ${SELECTOR_LIMIT})`.bold.underline; }
+        headingTransform() { return chalk.bold.underline(`Selector Count (Limit: ${SELECTOR_LIMIT})`); }
       }
     }
   });


### PR DESCRIPTION
This should improve the performance issues reported in  Issue #98.

The results of using `time bin/blessc chunk ./test/input --out-dir test/output`

### Before: ###

real	0m39.666s
user	0m39.014s
sys	0m0.171s

### After: ###

real	0m14.288s
user	0m8.230s
sys	0m0.119s
